### PR TITLE
LIBITD-400. Add sorting to index views.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'will_paginate-bootstrap'
 
 gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', branch: 'develop'
 
+gem 'ransack'
+
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
       mini_portile2 (~> 2.0.0.rc2)
     parser (2.3.0.7)
       ast (~> 2.2)
+    polyamorous (1.3.0)
+      activerecord (>= 3.0)
     powerpack (0.1.1)
     rack (1.6.4)
     rack-test (0.6.3)
@@ -124,6 +126,12 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     rake (11.1.2)
+    ransack (1.7.0)
+      actionpack (>= 3.0)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
+      i18n
+      polyamorous (~> 1.2)
     rdoc (4.2.2)
       json (~> 1.4)
     rubocop (0.39.0)
@@ -182,6 +190,7 @@ DEPENDENCIES
   jquery-rails
   minitest-reporters (= 1.0.5)
   rails (= 4.2.6)
+  ransack
   rubocop
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/controllers/auto_numbers_controller.rb
+++ b/app/controllers/auto_numbers_controller.rb
@@ -4,7 +4,9 @@ class AutoNumbersController < ApplicationController
   # GET /auto_numbers
   # GET /auto_numbers.json
   def index
-    @auto_numbers = AutoNumber.paginate(page: params[:page])
+    @q = AutoNumber.ransack(params[:q])
+    @q.sorts = 'id asc' if @q.sorts.empty?
+    @auto_numbers = @q.result.page(params[:page])
   end
 
   # GET /auto_numbers/1

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -4,7 +4,9 @@ class NamesController < ApplicationController
   # GET /names
   # GET /names.json
   def index
-    @names = Name.paginate(page: params[:page])
+    @q = Name.ransack(params[:q])
+    @q.sorts = 'initials asc' if @q.sorts.empty?
+    @names = @q.result.page(params[:page])
   end
 
   # GET /names/1

--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -4,7 +4,9 @@ class RepositoriesController < ApplicationController
   # GET /repositories
   # GET /repositories.json
   def index
-    @repositories = Repository.paginate(page: params[:page])
+    @q = Repository.ransack(params[:q])
+    @q.sorts = 'name asc' if @q.sorts.empty?
+    @repositories = @q.result.page(params[:page])
   end
 
   # GET /repositories/1

--- a/app/views/auto_numbers/index.html.erb
+++ b/app/views/auto_numbers/index.html.erb
@@ -13,10 +13,10 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th>Number</th>
-      <th>Entry date</th>
-      <th>Name</th>
-      <th>Repository</th>
+      <th><%= sort_link(@q, :id, 'Number') %></th>
+      <th><%= sort_link(@q, :entry_date) %></th>
+      <th><%= sort_link(@q, :name_initials, 'Name') %></th>
+      <th><%= sort_link(@q, :repository_name, 'Repository') %></th>
       <th></th>
     </tr>
   </thead>

--- a/app/views/names/index.html.erb
+++ b/app/views/names/index.html.erb
@@ -12,7 +12,7 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th>Initials</th>
+      <th><%= sort_link(@q, :initials) %></th>
       <th></th>
     </tr>
   </thead>

--- a/app/views/repositories/index.html.erb
+++ b/app/views/repositories/index.html.erb
@@ -12,7 +12,7 @@
 <table class="table table-striped">
   <thead>
     <tr>
-      <th>Name</th>
+      <th><%= sort_link(@q, :name) %></th>
       <th></th>
     </tr>
   </thead>

--- a/test/integration/auto_number_index_test.rb
+++ b/test/integration/auto_number_index_test.rb
@@ -10,4 +10,19 @@ class AutoNumberIndexTest < ActionDispatch::IntegrationTest
       assert_select 'a[href=?]', auto_number_path(auto_number), text: auto_number.id.to_s
     end
   end
+
+  test 'index including pagination and sorting' do
+    columns = %w(id entry_date name_initials repository_name)
+    columns.each do |column|
+      %w(asc desc).each do |order|
+        q_param = { s: column + ' ' + order }
+        get auto_numbers_path, q: q_param
+        assert_template 'auto_numbers/index'
+        assert_select '.pagination'
+        AutoNumber.ransack(q_param).result.paginate(page: 1).each do |auto_number|
+          assert_select 'a[href=?]', auto_number_path(auto_number), text: auto_number.id.to_s
+        end
+      end
+    end
+  end
 end

--- a/test/integration/name_index_test.rb
+++ b/test/integration/name_index_test.rb
@@ -10,4 +10,17 @@ class NameIndexTest < ActionDispatch::IntegrationTest
       assert_select 'a[href=?]', name_path(name), text: name.initials
     end
   end
+
+  test 'index including pagination and sorting' do
+    column = 'initials'
+    %w(asc desc).each do |order|
+      q_param = { s: column + ' ' + order }
+      get names_path, q: q_param
+      assert_template 'names/index'
+      assert_select '.pagination'
+      Name.ransack(q_param).result.paginate(page: 1).each do |name|
+        assert_select 'a[href=?]', name_path(name), text: name.initials
+      end
+    end
+  end
 end

--- a/test/integration/repository_index_test.rb
+++ b/test/integration/repository_index_test.rb
@@ -10,4 +10,17 @@ class RepositoryIndexTest < ActionDispatch::IntegrationTest
       assert_select 'a[href=?]', repository_path(repository), text: repository.name
     end
   end
+
+  test 'index including pagination and sorting' do
+    column = 'name'
+    %w(asc desc).each do |order|
+      q_param = { s: column + ' ' + order }
+      get repositories_path, q: q_param
+      assert_template 'repositories/index'
+      assert_select '.pagination'
+      Repository.ransack(q_param).result.paginate(page: 1).each do |repository|
+        assert_select 'a[href=?]', repository_path(repository), text: repository.name
+      end
+    end
+  end
 end


### PR DESCRIPTION
Use the [Ransack](https://github.com/activerecord-hackery/ransack) gem to add sorting to the index views for auto_number, name, and repository.

https://issues.umd.edu/browse/LIBITD-400