### PR TITLE
LIBITD-797. Updated to umd_lib_style 0.2.0.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ ruby '2.2.4'
 
 source 'https://rubygems.org'
 
+# use HTTPS for github repos (see https://bundler.io/git.html#security)
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.6'
 # Use sqlite3 as the database for Active Record
@@ -18,7 +21,7 @@ gem 'will_paginate', '~> 3.0.6'
 
 gem 'will_paginate-bootstrap'
 
-gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', branch: 'develop'
+gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', ref: '0.2.0'
 
 gem 'ransack'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
-  remote: git://github.com/rubycas/rubycas-client.git
-  revision: 195a4b70333029be474b0ac70efdc85bd4288861
+  remote: https://github.com/rubycas/rubycas-client.git
+  revision: 7b67c8f1b5515ee4e28479d640d2da0a5aadfbe0
   branch: master
   specs:
     rubycas-client (2.3.10.rc1)
       activesupport
 
 GIT
-  remote: git://github.com/umd-lib/umd_lib_style.git
-  revision: 1726422ac553ec066f3dab1c01932e5ea56815ef
-  branch: develop
+  remote: https://github.com/umd-lib/umd_lib_style.git
+  revision: f97253cf0d0249e15a0b1fa46ae4fe74bc3a2904
+  ref: 0.2.0
   specs:
-    umd_lib_style (0.0.1)
+    umd_lib_style (0.2.0)
       rails (~> 4.2.6)
 
 GEM


### PR DESCRIPTION
Includes the standard environment banners. Also updated the Gemfile to use https URIs for GitHub.

https://issue.umd.edu/browse/LIBITD-797