### PR TITLE
LIBITD-1070. Add Web Accessibility link to Autonumber

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'will_paginate', '~> 3.0.6'
 
 gem 'will_paginate-bootstrap'
 
-gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', ref: '0.2.0'
+gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', ref: '1.0.0'
 
 gem 'ransack'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: https://github.com/umd-lib/umd_lib_style.git
-  revision: f97253cf0d0249e15a0b1fa46ae4fe74bc3a2904
-  ref: 0.2.0
+  revision: b7b3eccf4518935ebdc21107f2bdb9eb3eeb59a0
+  ref: 1.0.0
   specs:
     umd_lib_style (0.2.0)
       rails (~> 4.2.6)
@@ -239,4 +239,4 @@ RUBY VERSION
    ruby 2.2.4p230
 
 BUNDLED WITH
-   1.13.6
+   1.16.0

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -27,7 +27,6 @@ a {
 
   &:hover {
     color: #fff;
-    background-color: #000;
   }
 }
 

--- a/test/integration/auto_number_index_test.rb
+++ b/test/integration/auto_number_index_test.rb
@@ -25,4 +25,10 @@ class AutoNumberIndexTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'index should include web accessibility link' do
+    get auto_numbers_path
+    assert_template 'auto_numbers/index'
+    assert_select 'a[href=?]', 'https://umd.edu/web-accessibility'
+  end
 end


### PR DESCRIPTION
Updated "umd_lib_style" gem dependency to v1.0.0, which includes the "Web Accessibility" link
in the footer.

Changed the application CSS to not show a black background behind hyperlinks when "hovering".

https://issues.umd.edu/browse/LIBITD-1070